### PR TITLE
fix: Use the all_commit_details attribute for commit time

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -172,13 +172,13 @@ steps:
           if [ "<<parameters.block-workflow>>" = "true" ] ;then
             echo "Orb parameter block-workflow is true."
             echo "This job will block until no previous workflows have *any* jobs running."
-            oldest_running_build_num=`jq 'sort_by(.committer_date)| .[0].build_num' /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq 'sort_by(.committer_date)| .[0].committer_date' /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq 'sort_by(.all_commit_details[0].committer_date)| .[0].build_num' /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq 'sort_by(.all_commit_details[0].committer_date)| .[0].all_commit_details[0].committer_date' /tmp/augmented_jobstatus.json`
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].committer_date" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.all_commit_details[0].committer_date)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.all_commit_details[0].committer_date)|  .[0].all_commit_details[0].committer_date" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."
@@ -198,7 +198,7 @@ steps:
         }
 
         load_current_workflow_values(){
-           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').committer_date' /tmp/augmented_jobstatus.json`
+           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').all_commit_details[0].committer_date' /tmp/augmented_jobstatus.json`
         }
 
         cancel_current_build(){


### PR DESCRIPTION
CircleCI API started returning `null` on the top level `committer_date` attribute, which is pretty consistent and results into builds being proceeding all together at the same time - which is bad for production.

Apparently, it seems that the `all_commit_details` attribute still returns the committer_date though, even when the top level committer_date attributre is null.

ie:

```sh

➜  curl -s -X GET -H "Circle-Token:${CIRCLECI_TOKEN}" -H "Content-Type: application/json" https://circleci.com/api/v1.1/project/github/gathertown/gather-town/tree/main\?filter\=running | jq ".[0].committer_date"

null

➜  curl -s -X GET -H "Circle-Token:${CIRCLECI_TOKEN}" -H "Content-Type: application/json" https://circleci.com/api/v1.1/project/github/gathertown/gather-town/tree/main\?filter\=running | jq ".[0].all_commit_details[0].committer_date"

"2023-09-14T10:08:39.000Z"
```

Let's rely on this attribute, so that we can have production deployments being queued properly.

### Notes
This fix will be used to create a new version of the private orb we maintain so that we can speed up the process and remediate the bug as quickly as possible. 
After that, makes sense to open an issue in the upstream repo, and initiate a discussion about this issue, which seems quite fragile and prone to breaking soon again.